### PR TITLE
Icon for termite and additional spacing between icons/titles

### DIFF
--- a/i3icons.go
+++ b/i3icons.go
@@ -122,7 +122,7 @@ func EventLoop(events chan i3ipc.Event, ipcsocket *i3ipc.IPCSocket, config map[s
 				}
 				// rename workspace
 				for _, windowname := range windownames {
-					newname = newname + windowname
+					newname = newname + " " + windowname + " "
 				}
 				ipcsocket.Command("rename workspace \"" + name + "\" to " + newname)
 			}

--- a/icons.config
+++ b/icons.config
@@ -34,6 +34,7 @@ Wireshark-gtk=
 Xfce4-terminal= 
 XTerm= 
 kitty= 
+Termite= 
 Zim= 
 wireshark-gtk= 
 Gitk=


### PR DESCRIPTION
I added the additional spacing because it looks to crammed together, especially if there are no icons for the program and titles are conjoined, which can result in a messy look.